### PR TITLE
Add simple health bar

### DIFF
--- a/game/player.py
+++ b/game/player.py
@@ -31,6 +31,8 @@ class Player(pygame.sprite.Sprite):
         self.jump_power = 10
         self.on_ground = False
         self.direction = 1  # 1=right, -1=left
+        self.max_health = settings.MAX_HEALTH
+        self.health = self.max_health
 
     def update(self, platforms):
         keys = pygame.key.get_pressed()
@@ -75,3 +77,10 @@ class Player(pygame.sprite.Sprite):
                 if vel_y < 0:
                     self.rect.top = p.rect.bottom
                     self.vel_y = 0
+
+    def draw_health(self, surface):
+        """Draw a simple health bar in the top-left corner."""
+        for i in range(self.max_health):
+            color = settings.RED if i < self.health else settings.GRAY
+            x = 10 + i * 18
+            pygame.draw.rect(surface, color, (x, 10, 16, 16))

--- a/game/settings.py
+++ b/game/settings.py
@@ -14,6 +14,10 @@ YELLOW = (255, 255, 0)
 GREEN = (0, 255, 0)
 ORANGE = (255, 165, 0)
 PURPLE = (128, 0, 128)
+GRAY = (160, 160, 160)
+
+# Health
+MAX_HEALTH = 10
 
 # Colors used for players. When a new player is created a random
 # value from this list will be assigned.

--- a/main.py
+++ b/main.py
@@ -73,6 +73,7 @@ def main():
         screen.fill(settings.WHITE)
         for sprite in all_sprites:
             screen.blit(sprite.image, (sprite.rect.x - camera_x, sprite.rect.y))
+        player.draw_health(screen)
         pygame.display.flip()
         clock.tick(settings.FPS)
 

--- a/multiplayer_main.py
+++ b/multiplayer_main.py
@@ -234,6 +234,7 @@ def main():
 
         screen.fill(settings.WHITE)
         scene.draw(screen, camera_x)
+        player.draw_health(screen)
         pygame.display.flip()
         clock.tick(settings.FPS)
 


### PR DESCRIPTION
## Summary
- add health constants to settings
- track health in `Player` and draw as red blocks
- render health bar in singleplayer and multiplayer modes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68429cad3c1083268f334caaadd763ce