### PR TITLE
Enable LAN support for multiplayer mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ A simple TCP server is included for experimental multiplayer support.
    ```bash
    python server.py
    ```
-2. Run the multiplayer client in another terminal:
+2. Run the multiplayer client on any machine in the same network. Specify the
+   server's IP address if it is running on a different machine:
    ```bash
-   python multiplayer_main.py
+   python multiplayer_main.py --host <SERVER_IP>
    ```
 
-Each running client connects to the server and shares player positions with others.
+Each running client connects to the server and shares player positions with
+others.

--- a/multiplayer_main.py
+++ b/multiplayer_main.py
@@ -1,5 +1,6 @@
 import socket
 import threading
+import argparse
 import pygame
 from pygame.locals import QUIT, KEYDOWN, KEYUP, K_f
 
@@ -9,8 +10,6 @@ from game.map import create_platforms
 from game.weapon import Bullet
 from game.utils import show_death_screen
 
-HOST = '127.0.0.1'
-PORT = 5001
 
 
 class NetworkClient:
@@ -144,11 +143,27 @@ class MultiplayerScene:
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Multiplayer client")
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Server hostname or IP address"
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=5001,
+        help="Server port"
+    )
+    args = parser.parse_args()
+
     pygame.init()
-    screen = pygame.display.set_mode((settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT))
+    screen = pygame.display.set_mode(
+        (settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT)
+    )
     clock = pygame.time.Clock()
 
-    client = NetworkClient(HOST, PORT)
+    client = NetworkClient(args.host, args.port)
     client.connect()
 
     player = Player(100, settings.SCREEN_HEIGHT - 100, client.color)


### PR DESCRIPTION
## Summary
- add command line args for the multiplayer client
- document connecting to the server on another machine

## Testing
- `python -m py_compile multiplayer_main.py server.py main.py game/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6842f885c5b88326b5bc6eac8b4efc07