### PR TITLE
Improve parkour by raising platforms

### DIFF
--- a/game/map.py
+++ b/game/map.py
@@ -24,12 +24,15 @@ def create_platforms():
             x += gap_width
 
     # ----- floating platforms and pillars -----
-    for i in range(200, settings.MAP_WIDTH, 600):
-        platforms.add(Platform(i, ground_y - 60, 80, 20))
-        platforms.add(Platform(i + 100, ground_y - 140, 100, 20))
-        platforms.add(Platform(i + 220, ground_y - 220, 120, 20))
+    for idx, i in enumerate(range(200, settings.MAP_WIDTH, 600)):
+        # gradually raise platform heights to create climbing sections
+        offset = idx * 50
+        platforms.add(Platform(i, ground_y - 60 - offset, 80, 20))
+        platforms.add(Platform(i + 100, ground_y - 140 - offset, 100, 20))
+        platforms.add(Platform(i + 220, ground_y - 220 - offset, 120, 20))
 
-    for i in range(500, settings.MAP_WIDTH, 800):
-        platforms.add(Platform(i, ground_y - 100, 40, 100))
+    for idx, i in enumerate(range(500, settings.MAP_WIDTH, 800)):
+        offset = idx * 50
+        platforms.add(Platform(i, ground_y - 100 - offset, 40, 100))
 
     return platforms

--- a/game/player.py
+++ b/game/player.py
@@ -28,7 +28,8 @@ class Player(pygame.sprite.Sprite):
         self.vel_x = 0
         self.vel_y = 0
         self.speed = 5
-        self.jump_power = 10
+        # slightly higher jump to make parkour easier
+        self.jump_power = 14
         self.on_ground = False
         self.direction = 1  # 1=right, -1=left
         self.max_health = settings.MAX_HEALTH


### PR DESCRIPTION
## Summary
- raise groups of platforms higher as the level progresses
- give players higher jump power so parkour is easier

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fb7e30788326a0462552c108b73b