### PR TITLE
Add fullscreen toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The game currently supports:
    ```
 
 Use `A` and `D` to move left and right, `W` to jump, and click with the left mouse button to shoot toward the cursor.
+Press `F` at any time to toggle fullscreen mode.
 
 Further improvements, including multiplayer features, may be added later.
 

--- a/game/utils.py
+++ b/game/utils.py
@@ -6,7 +6,8 @@ def show_death_screen(screen):
     """Display a simple death screen and wait for the user to quit."""
     font = pygame.font.SysFont(None, 72)
     text = font.render("You Died", True, settings.RED)
-    text_rect = text.get_rect(center=(settings.SCREEN_WIDTH // 2, settings.SCREEN_HEIGHT // 2))
+    screen_rect = screen.get_rect()
+    text_rect = text.get_rect(center=screen_rect.center)
 
     waiting = True
     while waiting:

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import random
 import pygame
-from pygame.locals import QUIT, MOUSEBUTTONDOWN
+from pygame.locals import QUIT, MOUSEBUTTONDOWN, KEYDOWN, K_f
 
 from game import settings
 from game.player import Player
@@ -13,6 +13,7 @@ def main():
     pygame.init()
     screen = pygame.display.set_mode((settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT))
     clock = pygame.time.Clock()
+    is_fullscreen = False
 
     player = Player(100, settings.SCREEN_HEIGHT - 100)
     bullets = pygame.sprite.Group()
@@ -36,6 +37,14 @@ def main():
         for event in pygame.event.get():
             if event.type == QUIT:
                 running = False
+            if event.type == KEYDOWN and event.key == K_f:
+                is_fullscreen = not is_fullscreen
+                if is_fullscreen:
+                    screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+                else:
+                    screen = pygame.display.set_mode(
+                        (settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT)
+                    )
             if event.type == MOUSEBUTTONDOWN and event.button == 1:
                 shooting = True
                 mouse_target = (event.pos[0] + camera_x, event.pos[1])

--- a/multiplayer_main.py
+++ b/multiplayer_main.py
@@ -162,6 +162,7 @@ def main():
         (settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT)
     )
     clock = pygame.time.Clock()
+    is_fullscreen = False
 
     client = NetworkClient(args.host, args.port)
     client.connect()
@@ -218,6 +219,14 @@ def main():
         for event in pygame.event.get():
             if event.type == QUIT:
                 running = False
+            if event.type == KEYDOWN and event.key == K_f:
+                is_fullscreen = not is_fullscreen
+                if is_fullscreen:
+                    screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+                else:
+                    screen = pygame.display.set_mode(
+                        (settings.SCREEN_WIDTH, settings.SCREEN_HEIGHT)
+                    )
             if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
                 shooting = True
                 mouse_target = (event.pos[0] + camera_x, event.pos[1])


### PR DESCRIPTION
## Summary
- toggle fullscreen with F key in single and multiplayer
- keep death screen centered on any window size
- document fullscreen controls in README

## Testing
- `python -m py_compile main.py multiplayer_main.py game/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6842fb8666d08326b6514a6b0907c9d0